### PR TITLE
make Googe Analytics optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128192873-1"></script>
+    <!-- Google Analytics -->
+    <!-- Replace UA-XXXXX-X with your Tracking-ID obtained from Google Analytics and remove the comments if you want to use Google Analytics
+         If compliance with EU's GDPR is necessary, consider the anonymize_ip parameter and an Opt-Out-Cookie.
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-XXXXX-X"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-128192873-1');
+      gtag('config', 'UA-XXXXX-X');
     </script>
+    -->
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
added a hint about needing one's own Google Analytics Tracking-ID 
and commented the Google Analytics code out by default since it needs an individual Tracking-ID